### PR TITLE
Implement --source command-line argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 ## Usage
 ```
-$ ghc-env 7.10.3 ghci     # run `ghci` 7.10.3
-$ ghc-env 7.10.3 bash     # run `bash` with `ghc` 7.10.3 in your PATH
-$ ghc-env 7.10.3          # open your default shell with `ghc` 7.10.3 in your PATH
-$ ghc-env                 # open your default shell with a default `ghc` in your PATH
+$ ghc-env 7.10.3 ghci            # run `ghci` 7.10.3
+$ ghc-env 7.10.3 bash            # run `bash` with `ghc` 7.10.3 in your PATH
+$ eval `ghc-env 7.10.3 --env`    # change current shell's PATH to include `ghc` 7.10.3 in PATH
+$ ghc-env 7.10.3                 # open your default shell with `ghc` 7.10.3 in your PATH
+$ ghc-env                        # open your default shell with a default `ghc` in your PATH
 ```
 
 ## Implementation

--- a/src/Args.hs
+++ b/src/Args.hs
@@ -8,6 +8,7 @@ import qualified Stack.Types.Version as Stack
 
 data Command = Exec String [String]
              | Source
+             deriving (Show, Eq)
 
 parseArgs :: [(String, String)] -> [String] -> (Version, Command)
 parseArgs env args = case args of

--- a/src/Args.hs
+++ b/src/Args.hs
@@ -17,7 +17,7 @@ parseArgs env args = case args of
     Just defaultVersion = parseVersion "7.10.3"
     parseCommand xs = case xs of
         ["--env"] -> Source
-        prog : args -> Exec prog args
+        prog : progArgs -> Exec prog progArgs
         [] -> Exec shell []
 
     shell = fromMaybe "/bin/sh" $ lookup "SHELL" env

--- a/src/Args.hs
+++ b/src/Args.hs
@@ -6,15 +6,21 @@ import           Data.String
 import           Stack.Types.Version (Version)
 import qualified Stack.Types.Version as Stack
 
-parseArgs :: [(String, String)] -> [String] -> (Version, (String, [String]))
+data Command = Exec String [String]
+             | Source
+
+parseArgs :: [(String, String)] -> [String] -> (Version, Command)
 parseArgs env args = case args of
   (parseVersion -> Just version) : xs -> (version, parseCommand xs)
   xs -> (defaultVersion, parseCommand xs)
   where
     Just defaultVersion = parseVersion "7.10.3"
     parseCommand xs = case xs of
-      y : ys -> (y, ys)
-      [] -> (fromMaybe "/bin/sh" $ lookup "SHELL" env, [])
+        ["--env"] -> Source
+        prog : args -> Exec prog args
+        [] -> Exec shell []
+
+    shell = fromMaybe "/bin/sh" $ lookup "SHELL" env
 
 parseVersion :: String -> Maybe Version
 parseVersion = Stack.parseVersion . fromString

--- a/src/GhcEnv.hs
+++ b/src/GhcEnv.hs
@@ -38,9 +38,14 @@ dummyStackFile = "resolver: lts-5.8"
 main :: IO ()
 main = do
   (version, command) <- parseArgs <$> getEnvironment <*> getArgs
-  paths <- ensureGhc version  
-  (modifyPath paths <$> lookupEnv "PATH") >>= setEnv "PATH"
-  uncurry spawnProcess command >>= waitForProcess >>= throwIO
+  paths <- ensureGhc version
+  paths' <- modifyPath paths <$> lookupEnv "PATH"
+  case command of
+      Exec prog args -> do
+          setEnv "PATH" paths'
+          spawnProcess prog args >>= waitForProcess >>= throwIO
+      Source -> do
+          putStrLn $ "PATH=" ++ paths'
 
 modifyPath :: [FilePath] -> Maybe String -> String
 modifyPath dirs mPath = intercalate [searchPathSeparator] path

--- a/test/ArgsSpec.hs
+++ b/test/ArgsSpec.hs
@@ -9,16 +9,22 @@ spec :: Spec
 spec = do
   describe "parseArgs" $ do
     it "parses GHC version and command" $ do
-      (first show $ parseArgs [] ["7.10.2", "bash"]) `shouldBe` ("7.10.2" , ("bash", []))
+      (call_ ["7.10.2", "bash"]) `shouldBe` ("7.10.2" , (Exec "bash" []))
 
     context "when command is not specified" $ do
       it "defaults to $SHELL" $ do
-        (first show $ parseArgs [("SHELL", "/bin/zsh")] ["7.10.2"]) `shouldBe` ("7.10.2" , ("/bin/zsh", []))
+        (call [("SHELL", "/bin/zsh")] ["7.10.2"]) `shouldBe` ("7.10.2" , Exec "/bin/zsh" [])
 
       context "when $SHELL is not defined" $ do
         it "defaults to /bin/sh" $ do
-          (first show $ parseArgs [] ["7.10.2"]) `shouldBe` ("7.10.2" , ("/bin/sh", []))
+          (call_ ["7.10.2"]) `shouldBe` ("7.10.2" , Exec "/bin/sh" [])
 
     context "when GHC version is not defined" $ do
       it "defaults to 7.10.3" $ do
-        (first show $ parseArgs [] ["bash"]) `shouldBe` ("7.10.3" , ("bash", []))
+        (call_ ["bash"]) `shouldBe` ("7.10.3" , Exec "bash" [])
+
+    it "parses --env correctly" $ do
+      (call_ ["7.10.2", "--env"]) `shouldBe` ("7.10.2", Source)
+  where
+    call_ args = call [] args
+    call env args = first show $ parseArgs env args


### PR DESCRIPTION
When passed, instead of starting a new subprocess with a changed environment,
the intended new value of $PATH is printed out in a format suitable to
be piped into eval:

```
eval `ghc-env --source`
```

will result in the current shell's environment being changed to include
the selected GHC version in $PATH.
